### PR TITLE
Diff gene tests

### DIFF
--- a/src/brain_atlas/diff_exp.py
+++ b/src/brain_atlas/diff_exp.py
@@ -79,6 +79,6 @@ def mannwhitneyu(x, y, use_continuity=True):
     with np.errstate(divide="ignore", invalid="ignore"):
         z = (bigu - meanrank) / sd
 
-    logp = np.clip(2 * scipy.stats.norm.logsf(z), 0, 1)
+    logp = np.minimum(scipy.stats.norm.logsf(z) + np.log(2), 0)
 
     return u2, logp


### PR DESCRIPTION
Tweaked Mann Whitney code to return log p-values, as there is a lot of underflow. 

`find_genes.py` has functions to a) construct a hierarchical tree from a set of clusters and b) walk down the tree, computing left vs right tests as well as above vs below tests. This strategy provides a relatively succinct set of gene lists for annotation.