### PR TITLE
Simplified tree code

### DIFF
--- a/src/brain_atlas/find_genes.py
+++ b/src/brain_atlas/find_genes.py
@@ -93,9 +93,9 @@ def cluster_reduce(
     for i in range(0, n_cells, blocksize):
         log.debug(f"{i} ...")
         cluster_i = clusters[i : i + blocksize]
-        i_data = reduce_fn(data[i : i + blocksize, :])
+        data_i = reduce_fn(data[i : i + blocksize, :])
         for j in np.unique(cluster_i):
-            cluster_arr[j] += i_data[cluster_i == j, :].sum(0)
+            cluster_arr[j] += data_i[cluster_i == j, :].sum(0)
 
     return cluster_arr
 
@@ -170,9 +170,7 @@ def generic_de(
     subsample: int = None,
 ):
     assert cluster_nz.shape[0] == cluster_counts.shape[0]
-    assert np.array_equal(
-        cluster_counts.sum(1).nonzero()[0], cluster_counts.nonzero()[0]
-    )
+    assert np.array_equal(cluster_nz.sum(1).nonzero()[0], cluster_counts.nonzero()[0])
 
     for k in node_tree:
         for comp, c_i, c_j in get_comps(k, node_tree):

--- a/src/brain_atlas/util/tree.py
+++ b/src/brain_atlas/util/tree.py
@@ -61,9 +61,13 @@ class MultiNode:
 NodeTree = Dict[Key, MultiNode]
 
 
-def to_tree(leaf_list: List[Key], node_counts: Counter[Key]) -> NodeTree:
+def to_tree(leaf_list: List[Key], node_counts: Counter[Key] = None) -> NodeTree:
     node_list = leaf_list.copy()
     node_tree = dict()
+
+    if node_counts is None:
+        # leaf nodes are count 1, everything else 0
+        node_counts = defaultdict(int, {k: 1 for k in leaf_list})
 
     # internal nodes
     all_nodes = {k[:i] for k in leaf_list for i in range(len(k))}

--- a/src/brain_atlas/util/tree.py
+++ b/src/brain_atlas/util/tree.py
@@ -74,7 +74,7 @@ def to_tree(leaf_list: List[Key], node_counts: Counter[Key]) -> NodeTree:
     for k in node_list[:-1]:
         node_children[k[:-1]].append(k)
 
-    # initialize node objects
+    # initialize node objects from the bottom up
     for i, k in enumerate(node_list):
         if i < len(leaf_list):
             node_tree[k] = MultiNode(i, k, count=node_counts[k])


### PR DESCRIPTION
This PR refactors the tree code a bit to make the resulting object more useful:
 * nodes have an `index` attribute which can be used as a consistent identifier
 * they also have `count` to store the count of cells in a given subtree

The de code in find_genes was modified to match and also be simpler by requiring fewer inputs.