### PR TITLE
small tweak to interface of neighbor functions

### DIFF
--- a/src/brain_atlas/gene_selection.py
+++ b/src/brain_atlas/gene_selection.py
@@ -25,8 +25,8 @@ def dask_pblock(counts: ArrayLike, numis: ArrayLike = None, blocksize: int = 128
     if numis is None:
         numis = counts.sum(1, keepdims=True)
 
-    exp_pct_nz = np.zeros(exp.shape)  # 1 x n_genes
-    var_pct_nz = np.zeros(exp.shape)  # 1 x n_genes
+    exp_nz = np.zeros(exp.shape)  # 1 x n_genes
+    var_nz = np.zeros(exp.shape)  # 1 x n_genes
 
     log.debug("computing expected percent nonzero")
     # run in chunks (still large, but seems easier for dask to handle)
@@ -36,23 +36,21 @@ def dask_pblock(counts: ArrayLike, numis: ArrayLike = None, blocksize: int = 128
 
         prob_zero = np.exp(-exp.T.dot(numis[i : i + blocksize, :].T))  # n_genes x b
 
-        exp_pct_nz_b = (1 - prob_zero).sum(1)  # n_genes
-        var_pct_nz_b = (prob_zero * (1 - prob_zero)).sum(1)
+        exp_nz_b = (1 - prob_zero).sum(1)  # n_genes
+        var_nz_b = (prob_zero * (1 - prob_zero)).sum(1)
 
-        exp_pct_nz_b, var_pct_nz_b = da.compute(exp_pct_nz_b, var_pct_nz_b)
+        exp_nz_b, var_nz_b = da.compute(exp_nz_b, var_nz_b)
 
-        exp_pct_nz += exp_pct_nz_b
-        var_pct_nz += var_pct_nz_b
+        exp_nz += exp_nz_b
+        var_nz += var_nz_b
 
-    exp_pct_nz = exp_pct_nz.squeeze() / n_cells
-    std_pct_nz = np.sqrt(var_pct_nz.squeeze()) / n_cells
+    exp_nz = exp_nz.squeeze() / n_cells
+    std_nz = np.sqrt(var_nz.squeeze()) / n_cells
 
     log.debug("... done")
 
     exp_p = np.zeros_like(pct)
-    ix = (std_pct_nz != 0).flatten()
-    exp_p[ix] = scipy.stats.norm.logcdf(
-        pct[ix], loc=exp_pct_nz[ix], scale=std_pct_nz[ix]
-    )
+    ix = (std_nz != 0).flatten()
+    exp_p[ix] = scipy.stats.norm.logcdf(pct[ix], loc=exp_nz[ix], scale=std_nz[ix])
 
-    return exp_pct_nz, pct, exp_p
+    return exp_nz, pct, exp_p

--- a/src/brain_atlas/gene_selection.py
+++ b/src/brain_atlas/gene_selection.py
@@ -44,9 +44,8 @@ def dask_pblock(counts: ArrayLike, numis: ArrayLike = None, blocksize: int = 128
         exp_pct_nz += exp_pct_nz_b
         var_pct_nz += var_pct_nz_b
 
-    exp_pct_nz = exp_pct_nz.flatten() / n_cells
-    var_pct_nz = var_pct_nz.flatten() / (n_cells * n_cells)
-    std_pct_nz = np.sqrt(var_pct_nz)
+    exp_pct_nz = exp_pct_nz.squeeze() / n_cells
+    std_pct_nz = np.sqrt(var_pct_nz.squeeze()) / n_cells
 
     log.debug("... done")
 

--- a/src/brain_atlas/scripts/subcluster.py
+++ b/src/brain_atlas/scripts/subcluster.py
@@ -222,9 +222,9 @@ def main(
         log.info("Computing edge list via brute-force algo")
         if tree.jaccard:
             log.debug("calculating jaccard scores")
-            edges = neighbors.k_jaccard_edgelist(knn_data, k=k_neighbors + 1)
+            edges, weights = neighbors.k_jaccard_edgelist(knn_data, k=k_neighbors + 1)
         else:
-            edges = neighbors.k_cosine_edgelist(knn_data, k=k_neighbors + 1)
+            edges, weights = neighbors.k_cosine_edgelist(knn_data, k=k_neighbors + 1)
     else:
         if valid_cache and tree.knn.exists():
             log.info(f"Loading cached kNN from {tree.knn}")
@@ -248,18 +248,18 @@ def main(
         if tree.jaccard:
             # compute jaccard on kNN
             log.info("Computing SNN")
-            edges = neighbors.kng_to_jaccard(kng)
+            edges, weights = neighbors.kng_to_jaccard(kng)
         else:
             if knd is None:
                 log.debug(f"Loading kNN distances from {tree.knn}")
                 knd = da.from_zarr(tree.knn, "knd").compute()
 
             log.info("Creating edge list")
-            edges = neighbors.kng_to_edgelist(kng, 1 - knd)
+            edges, weights = neighbors.kng_to_edgelist(kng, 1 - knd)
 
     # create igraph from edge list
     log.info(f"Building graph with {edges.shape[0]} edges")
-    graph = ig.Graph(n=n_cells, edges=edges[:, :2], edge_attrs={"weight": edges[:, 2]})
+    graph = ig.Graph(n=n_cells, edges=edges, edge_attrs={"weight": weights})
 
     if high_res:
         bs = range(1, 10)


### PR DESCRIPTION
Small refactor of how neighbors and edge weights/distances are stored--was using one array for both but there's no need for that, and this way saves some memory by storing edges as int32 (assuming we don't have to cluster billions of cells anytime soon).

The `kng_to_full_jaccard` method snuck in here as well, which calculates the SNN graph for all neighbors-of-neighbors, getting pretty close to the full graph.