### PR TITLE
Artifact filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/src/brain_atlas/find_genes.py
+++ b/src/brain_atlas/find_genes.py
@@ -393,9 +393,16 @@ def get_gene_lists(
 
 
 def collapse_tree(
-    node_tree: NodeTree, sib_results: ResultsDict, min_de: int = 5, max_p: float = -10.0
+    node_tree: NodeTree,
+    sib_results: ResultsDict,
+    min_de: int = 5,
+    max_p: float = -10.0,
+    max_nz_b: float = 0.2,
 ):
-    sib_totals = {k: get_de_count(sib_results[k], max_p=max_p) for k in sib_results}
+    sib_totals = {
+        k: get_de_count(sib_results[k], max_p=max_p, max_nz_b=max_nz_b)
+        for k in sib_results
+    }
 
     exclude = set()
     new_leaf_list = []

--- a/src/brain_atlas/gene_selection.py
+++ b/src/brain_atlas/gene_selection.py
@@ -16,10 +16,11 @@ def dask_pblock(counts: ArrayLike, numis: ArrayLike = None, blocksize: int = 128
 
     # pre-compute these values
     log.debug("computing percent nonzero per gene")
-    pct = da.compute((counts > 0).sum(0) / n_cells)[0]
+    pct = da.compute(np.sign(counts).sum(0))[0]
+    pct = pct / n_cells
 
     log.debug("computing average expression per gene")
-    exp = counts.sum(0, keepdims=True)
+    exp = da.compute(counts.sum(0, keepdims=True))[0]  # 1 x n_genes
     exp = exp / exp.sum()
 
     if numis is None:
@@ -34,12 +35,11 @@ def dask_pblock(counts: ArrayLike, numis: ArrayLike = None, blocksize: int = 128
         if i % (blocksize * 10) == 0:
             log.debug(f"{i} ...")
 
-        prob_zero = np.exp(-exp.T.dot(numis[i : i + blocksize, :].T))  # n_genes x b
+        numis_t = da.compute(numis[i : i + blocksize, :])[0].T
+        prob_zero = np.exp(-exp.T.dot(numis_t))  # n_genes x b
 
         exp_nz_b = (1 - prob_zero).sum(1)  # n_genes
         var_nz_b = (prob_zero * (1 - prob_zero)).sum(1)
-
-        exp_nz_b, var_nz_b = da.compute(exp_nz_b, var_nz_b)
 
         exp_nz += exp_nz_b
         var_nz += var_nz_b

--- a/src/brain_atlas/scripts/subcluster.py
+++ b/src/brain_atlas/scripts/subcluster.py
@@ -214,7 +214,9 @@ def main(
         r = r[ix, :]
         logp = logp[ix, :]
 
-        d_i_mem = d_i_mem[:, ~((r >= filter_threshold) & (logp < -5))]
+        with dask.config.set(**{"array.slicing.split_large_chunks": False}):
+            d_i_mem = d_i_mem[:, ~((r >= filter_threshold) & (logp < -5))]
+
         n_genes = d_i_mem.shape[1]
 
         log.info(f"Filtered to {n_genes} genes")


### PR DESCRIPTION
This adds the ability to filter the selected gene list to remove anything that correlates with a specified "artifact" gene, e.g. Malat1 or Ubb. The idea is to remove such artifact signals from showing up in the clustering, although the impact has not been fully evaluated.

Also, this PR includes some modifications to gene selection code which prevents a lot of the Dask scheduler deadlocks we had before, and some cleanup of the diff expression module.